### PR TITLE
Enables pipeline input for -Credential parameter

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.2.1.{build}
+version: 0.2.2.{build}
 
 #branches:
 #  only:

--- a/docs/Connect-To.md
+++ b/docs/Connect-To.md
@@ -167,8 +167,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Disconnect-From.md
+++ b/docs/Disconnect-From.md
@@ -111,8 +111,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Get-CredentialStore.md
+++ b/docs/Get-CredentialStore.md
@@ -71,8 +71,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Get-CredentialStoreItem.md
+++ b/docs/Get-CredentialStoreItem.md
@@ -101,8 +101,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/New-CredentialStore.md
+++ b/docs/New-CredentialStore.md
@@ -5,79 +5,56 @@ online version: https://github.com/OCram85/PSCredentialStore
 schema: 2.0.0
 ---
 
-# New-CredentialStore
+# Get-CredentialStoreItem
 
 ## SYNOPSIS
-Creates a new credential store File
+Returns the Credential from a given remote host item.
 
 ## SYNTAX
 
 ### Private (Default)
 ```
-New-CredentialStore [-Force] [<CommonParameters>]
+Get-CredentialStoreItem -RemoteHost <String> [-Identifier <String>] [<CommonParameters>]
 ```
 
 ### Shared
 ```
-New-CredentialStore [-Shared] [-Path <String>] [-Force] [<CommonParameters>]
+Get-CredentialStoreItem [-Path <String>] -RemoteHost <String> [-Identifier <String>] [-Shared]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-You need to run this script first to create a new credential store before you try to
-save new credentials with New-CredentialStoreItem.
+Return the credential as PSCredential object.
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```
-New-CredentialStore
+$myCreds = Get-CredentialStoreItem -Path "C:\TMP\mystore.json" -RemoteHost "esx01.myside.local"
 ```
-
-# Creates a new private CredentialStore
-
-### EXAMPLE 2
-```
-New-CredentialStore -Force
-```
-
-# Resets an existing private CredentialStore
-
-### EXAMPLE 3
-```
-New-CredentialStore -Shared
-```
-
-# Creates a new shared CredentialStore
-
-### EXAMPLE 4
-```
-New-CredentialStore -Shared -Path "C:\TMP\CredentialStore.json"
-```
-
-# Creates a new shared CredentialStore in the given location.
 
 ## PARAMETERS
 
-### -Force
-Use this switch to reset an existing store.
-The complete content will be wiped.
+### -Identifier
+Provide a custom identifier to the given remote host key.
+This enables you to store multiple credentials
+for a single remote host entry.
+For example ad/sys1, ftp/sys1, mssql/sys1
 
 ```yaml
-Type: SwitchParameter
+Type: String
 Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Path
-Define a location for the new shared CredentialStore.
-The default store will be created in
-$Env:ProgramData\PSCredentialStore dir.
+Define a custom path to a shared CredentialStore.
 
 ```yaml
 Type: String
@@ -91,11 +68,25 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -RemoteHost
+Specify the host, for which you would like to change the credentials.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Shared
-Creates a CredentialStore in the Shared mode.
-This enables you to read the CredentialStore Items on
-different systems or profiles.
-In addition you can optionally provide a custom path wit the -Path parameter.
+Switch to shared mode with this param.
+This enforces the command to work with a shared CredentialStore which
+can be decrypted across systems.
 
 ```yaml
 Type: SwitchParameter
@@ -110,8 +101,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -119,11 +109,11 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## OUTPUTS
 
-### [None]
+### [System.Management.Automation.PSCredential]
 
 ## NOTES
 \`\`\`
-File Name   : New-CredentialStore.ps1
+File Name   : Get-CredentialStoreItem.ps1
 Author      : Marco Blessing - marco.blessing@googlemail.com
 Requires    :
 \`\`\`

--- a/docs/New-CredentialStoreItem.md
+++ b/docs/New-CredentialStoreItem.md
@@ -119,8 +119,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/PSCredentialStore.md
+++ b/docs/PSCredentialStore.md
@@ -12,35 +12,35 @@ Locale: en-US
 
 ## PSCredentialStore Cmdlets
 ### [Connect-To](Connect-To.md)
-{{Manually Enter Connect-To Description Here}}
+Connects to the given host using the stored CredentialStoreItem.
 
 ### [Disconnect-From](Disconnect-From.md)
-{{Manually Enter Disconnect-From Description Here}}
+Terminates a session established with Connect-To using a CredentialStoreItem.
 
 ### [Get-CredentialStore](Get-CredentialStore.md)
-{{Manually Enter Get-CredentialStore Description Here}}
+Reads the complete content of the credential store and returns it as a new object.
 
 ### [Get-CredentialStoreItem](Get-CredentialStoreItem.md)
-{{Manually Enter Get-CredentialStoreItem Description Here}}
+Returns the Credential from a given remote host item.
 
-### [New-CredentialStore](New-CredentialStore.md)
-{{Manually Enter New-CredentialStore Description Here}}
+### [Get-CredentialStoreItem](Get-CredentialStoreItem.md)
+Returns the Credential from a given remote host item.
 
 ### [New-CredentialStoreItem](New-CredentialStoreItem.md)
-{{Manually Enter New-CredentialStoreItem Description Here}}
+Adds a credential store item containing host, user and password to the given store.
 
 ### [Remove-CredentialStoreItem](Remove-CredentialStoreItem.md)
-{{Manually Enter Remove-CredentialStoreItem Description Here}}
+Remove the given credentials from the credential store.
 
 ### [Set-CredentialStoreItem](Set-CredentialStoreItem.md)
-{{Manually Enter Set-CredentialStoreItem Description Here}}
+Changes the credentials for the given remote host in the store.
 
 ### [Test-CredentialStore](Test-CredentialStore.md)
-{{Manually Enter Test-CredentialStore Description Here}}
+Returns the credential store state.
 
 ### [Test-CredentialStoreItem](Test-CredentialStoreItem.md)
-{{Manually Enter Test-CredentialStoreItem Description Here}}
+Checks if the given RemoteHost identifier combination exists in the credential store.
 
 ### [Test-CSConnection](Test-CSConnection.md)
-{{Manually Enter Test-CSConnection Description Here}}
+Returns the connection state of a given type to the remote host.
 

--- a/docs/Remove-CredentialStoreItem.md
+++ b/docs/Remove-CredentialStoreItem.md
@@ -102,8 +102,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Set-CredentialStoreItem.md
+++ b/docs/Set-CredentialStoreItem.md
@@ -102,8 +102,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Test-CSConnection.md
+++ b/docs/Test-CSConnection.md
@@ -61,8 +61,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Test-CredentialStore.md
+++ b/docs/Test-CredentialStore.md
@@ -71,8 +71,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Test-CredentialStoreItem.md
+++ b/docs/Test-CredentialStoreItem.md
@@ -110,8 +110,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/src/Item/New-CredentialStoreItem.ps1
+++ b/src/Item/New-CredentialStoreItem.ps1
@@ -55,9 +55,9 @@ function New-CredentialStoreItem {
         [ValidateNotNullOrEmpty()]
         [string]$Identifier,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true)]
         [ValidateNotNullOrEmpty()]
-        [pscredential]$Credential,
+        [PSCredential]$Credential,
 
         [Parameter(Mandatory = $false, ParameterSetName = "Shared")]
         [switch]$Shared

--- a/src/Item/Set-CredentialStoreItem.ps1
+++ b/src/Item/Set-CredentialStoreItem.ps1
@@ -53,6 +53,10 @@ function Set-CredentialStoreItem {
         [Parameter(Mandatory = $false, ParameterSetName = "Shared")]
         [string]$Identifier,
 
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true)]
+        [ValidateNotNullOrEmpty()]
+        [PSCredential]$Credential,
+
         [Parameter(Mandatory = $false, ParameterSetName = "Shared")]
         [switch]$Shared
     )
@@ -83,7 +87,9 @@ function Set-CredentialStoreItem {
         $CredentialName = $RemoteHost
     }
 
-    $Creds = Get-Credential -Message $CredentialName
+    if (-not($Credential)) {
+        $Creds = Get-Credential -Message $CredentialName
+    }
 
     if ($Creds.UserName) {
         if ($CSContent.Type -eq "Shared") {

--- a/tests/Item/02_New-CredentialStoreItem.Tests.ps1
+++ b/tests/Item/02_New-CredentialStoreItem.Tests.ps1
@@ -98,5 +98,16 @@ Describe "New-CredentialStoreItem" {
             { New-CredentialStoreItem -Path 'C:\missingStore.json' -RemoteHost 'notrelevant' } | Should -Throw "Could not add anything"
         }
     }
+    Context "Testing pipeline paramter" {
+        It "Add the item with credential value from pipe" {
+            $UserName = 'pipeUser'
+            $Password = ConvertTo-SecureString -String "pipePasswd" -AsPlainText -Force
+            { [PSCredential]::new($UserName, $Password) | New-CredentialStoreItem -RemoteHost 'PipeHost' } | Should -Not -Throw
+        }
+
+        It "Testing written item" {
+            (Get-CredentialStoreItem -RemoteHost 'PipeHost').UserName | Should -Be 'PipeHost'
+        }
+    }
 
 }

--- a/tests/Item/02_New-CredentialStoreItem.Tests.ps1
+++ b/tests/Item/02_New-CredentialStoreItem.Tests.ps1
@@ -106,7 +106,7 @@ Describe "New-CredentialStoreItem" {
         }
 
         It "Testing written item" {
-            (Get-CredentialStoreItem -RemoteHost 'PipeHost').UserName | Should -Be 'PipeHost'
+            (Get-CredentialStoreItem -RemoteHost 'PipeHost').UserName | Should -Be 'pipeUser'
         }
     }
 


### PR DESCRIPTION
This PR fixes #19. Instead of adding more parameters for customizing the credential dialog, I decided to enable the pipeline support for this parameter / value. 