### PR TITLE
Fix Connect-To -Type CiscoUcs

### DIFF
--- a/src/Connection/Connect-To.ps1
+++ b/src/Connection/Connect-To.ps1
@@ -175,7 +175,7 @@ function Connect-To {
             switch ($Type) {
                 "CiscoUcs" {
                     try {
-                        $handle = Connect-Ucs -Name $RemoteHost -Credential $creds -ErrorAction Stop
+                        $handle = Connect-Ucs -Name $RemoteHost -Credential $creds -ErrorAction Stop -NotDefault
                         $ExecutionContext.SessionState.PSVariable.Set("DefaultUcs", $handle)
                     }
 


### PR DESCRIPTION
Fixes Connect-To for the provider CiscoUcs. Up till now, this was no longer working. Adding -NotDefault to the parameters of the command, it is back to working condition.